### PR TITLE
fixing the files glob to include all files in lib/ except spec ones

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
   "license": "MIT",
   "main": "lib/connection.js",
   "files": [
-    "lib/*.js",
-    "lib/*.d.ts"
+    "lib/*.{js,d.ts}",
+    "lib/!(spec)/**/*.{js,d.ts}"
   ],
   "devDependencies": {
     "@types/jest": "^27.0.2",


### PR DESCRIPTION
After this change, lib/utils files are now included:
```
❯ npm pack --dry-run
npm notice
npm notice 📦  cssmodules-language-server@1.2.0
npm notice === Tarball Contents ===
npm notice 1.1kB  LICENSE
npm notice 2.8kB  README.md
npm notice 31B    lib/cli.d.ts
npm notice 364B   lib/cli.js
npm notice 641B   lib/CompletionProvider.d.ts
npm notice 4.4kB  lib/CompletionProvider.js
npm notice 111B   lib/connection.d.ts
npm notice 3.2kB  lib/connection.js
npm notice 776B   lib/DefinitionProvider.d.ts
npm notice 5.4kB  lib/DefinitionProvider.js
npm notice 192B   lib/textDocuments.d.ts
npm notice 356B   lib/textDocuments.js
npm notice 2.3kB  lib/utils.d.ts
npm notice 14.2kB lib/utils.js
npm notice 550B   lib/utils/resolveAliasedImport.d.ts
npm notice 2.7kB  lib/utils/resolveAliasedImport.js
npm notice 1.6kB  package.json
npm notice === Tarball Details ===
npm notice name:          cssmodules-language-server
npm notice version:       1.2.0
npm notice filename:      cssmodules-language-server-1.2.0.tgz
npm notice package size:  10.2 kB
npm notice unpacked size: 40.7 kB
npm notice shasum:        b8909a67494fa910bb99b603704ae33dbe151c34
npm notice integrity:     sha512-oJu3f1jrmx0D2[...]5XtRzpr3HaXJw==
npm notice total files:   17
npm notice
cssmodules-language-server-1.2.0.tgz
```