### PR TITLE
Change nomenclature after Neovim 8

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ require'lspconfig'.cssmodules_ls.setup {
 require'lspconfig'.cssmodules_ls.setup {
     on_attach = function (client)
         -- avoid accepting `go-to-definition` responses from this LSP
-        client.server_capabilities.goto_definition = false
+        client.server_capabilities.definitionProvider = false
         custom_on_attach(client)
     end,
 }

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ require'lspconfig'.cssmodules_ls.setup {
 require'lspconfig'.cssmodules_ls.setup {
     on_attach = function (client)
         -- avoid accepting `go-to-definition` responses from this LSP
-        client.resolved_capabilities.goto_definition = false
+        client.server_capabilities.goto_definition = false
         custom_on_attach(client)
     end,
 }

--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ require'lspconfig'.cssmodules_ls.setup {
 ```lua
 require'lspconfig'.cssmodules_ls.setup {
     on_attach = function (client)
-        -- avoid accepting `go-to-definition` responses from this LSP
+        -- avoid accepting `definitionProvider` responses from this LSP
         client.server_capabilities.definitionProvider = false
         custom_on_attach(client)
     end,


### PR DESCRIPTION
There have been changes in neovim 8 see: https://github.com/neovim/nvim-lspconfig/issues/1891#issuecomment-1157964108

Updated part of README to match the current property used in neovim 8.