### PR TITLE
Add section for AstroNvim configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ require'lspconfig'.cssmodules_ls.setup {
 ```
 
 ### [coc.nvim](https://github.com/neoclide/coc.nvim)
+
 ```vim
 let cssmodules_config = {
 \ "command": "cssmodules-language-server",

--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ coc#config('languageserver.cssmodules', cssmodules_config)
 ```
 
 ### [AstroNvim](https://github.com/AstroNvim/AstroNvim)
+
 As per [`AstroNvim's documentation`](https://astronvim.github.io/#%EF%B8%8F-installation), you can install cssmodules_ls with:
 
 ```vim

--- a/README.md
+++ b/README.md
@@ -50,7 +50,6 @@ require'lspconfig'.cssmodules_ls.setup {
 ```
 
 ### [coc.nvim](https://github.com/neoclide/coc.nvim)
-
 ```vim
 let cssmodules_config = {
 \ "command": "cssmodules-language-server",
@@ -61,6 +60,31 @@ let cssmodules_config = {
 \ }
 coc#config('languageserver.cssmodules', cssmodules_config)
 ```
+
+### [AstroNvim](https://github.com/AstroNvim/AstroNvim)
+As per [`AstroNvim's documentation`](https://astronvim.github.io/#%EF%B8%8F-installation), you can install cssmodules_ls with:
+
+```vim
+:TSInstall cssmodules_ls
+```
+
+**Known issue**: since AstroNvim uses `nvim-lspconfig`, it suffers from the same issue as above. Here's a workaround to be inserted into init.nvim:
+```lua
+  -- previous config
+  lsp = {
+    -- previous configuration
+    ["server-settings"] = {
+      cssmodules_ls = {
+        capabilities = {
+          definitionProvider = false,
+        },
+      },
+    },
+}
+```
+From then, you can use `gI` which is the default shortcut for (go to implementation) as opposed to the usual `gd`.
+
+For more information on how to config LSP for AstroNvim, please refer to the [`Advanced LSP`](https://astronvim.github.io/Recipes/advanced_lsp) part of the documentation.
 
 ## Initialization options
 


### PR DESCRIPTION
AstroNvim is a feature-rich neovim config for beginners. It makes neovim approachable for many beginners such as me and it uses nvim-lspconfig under the hood.

I struggled with porting the "known issue" fix from nvim-lspconfig to the existing AstroNvim configuration, since it differs in structure / config file location.