### PR TITLE
allow resolving in tsconfig even when no paths

### DIFF
--- a/src/spec/resolveAliasedFilepath.spec.ts
+++ b/src/spec/resolveAliasedFilepath.spec.ts
@@ -45,7 +45,7 @@ describe('utils: resolveAliaedFilepath', () => {
         expect(result).toEqual(expected);
     });
 
-    it('returns null when "paths" is not set in the config', () => {
+    it('returns null when "paths" is not set in the config and path does not match', () => {
         (lilconfigSync as jest.Mock).mockReturnValueOnce({
             search: () => ({
                 config: {
@@ -57,6 +57,7 @@ describe('utils: resolveAliaedFilepath', () => {
                 filepath: '/path/to/config',
             }),
         });
+        (existsSync as jest.Mock).mockReturnValue(false);
         const result = resolveAliasedImport({
             location: '',
             importFilepath: '',
@@ -66,7 +67,29 @@ describe('utils: resolveAliaedFilepath', () => {
         expect(result).toEqual(expected);
     });
 
-    it('returns null when no alias matched import path', () => {
+    it('returns resolved filepath when "paths" is not set in the config, and file exists', () => {
+        (lilconfigSync as jest.Mock).mockReturnValueOnce({
+            search: () => ({
+                config: {
+                    compilerOptions: {
+                        baseUrl: './',
+                        // missing "paths"
+                    },
+                },
+                filepath: '/path/to/tsconfig.json',
+            }),
+        });
+        (existsSync as jest.Mock).mockReturnValue(true);
+        const result = resolveAliasedImport({
+            location: '',
+            importFilepath: 'src/styles/file.css',
+        });
+        const expected = '/path/to/src/styles/file.css';
+
+        expect(result).toEqual(expected);
+    });
+
+    it('returns baseUrl-mapped path when no alias matched import path', () => {
         (lilconfigSync as jest.Mock).mockReturnValueOnce({
             search: () => ({
                 config: {
@@ -84,7 +107,7 @@ describe('utils: resolveAliaedFilepath', () => {
             location: '',
             importFilepath: '@foo',
         });
-        const expected = null;
+        const expected = '/path/to/@foo';
 
         expect(result).toEqual(expected);
     });

--- a/src/utils/resolveAliasedImport.ts
+++ b/src/utils/resolveAliasedImport.ts
@@ -88,20 +88,31 @@ export const resolveAliasedImport = ({
                 return resolvedFileLocation;
             }
         }
-    }
 
-    // fallback to baseUrl
-    // if paths is not defined, don't use the fallback for baseUrl
-
-    if (validate.string(potentialBaseUrl)) {
+        // fallback to baseUrl of '.' only when paths are defined and valid
         const resolvedFileLocation = path.resolve(
             configLocation,
-            potentialBaseUrl,
+            baseUrl,
             importFilepath,
         );
 
         if (fs.existsSync(resolvedFileLocation)) {
             return resolvedFileLocation;
+        }
+    } else {
+        // no fallback to baseUrl of '.' if paths are not valid
+        // typescript only provides the '.' default when paths are set
+        // otherwise, no imports relative to project root (or baseUrl) are allowed
+        if (validate.string(potentialBaseUrl)) {
+            const resolvedFileLocation = path.resolve(
+                configLocation,
+                potentialBaseUrl,
+                importFilepath,
+            );
+
+            if (fs.existsSync(resolvedFileLocation)) {
+                return resolvedFileLocation;
+            }
         }
     }
 

--- a/src/utils/resolveAliasedImport.ts
+++ b/src/utils/resolveAliasedImport.ts
@@ -90,9 +90,12 @@ export const resolveAliasedImport = ({
         }
     }
 
-    // fallback to baseUrl
-    // if paths is not defined, don't use the fallback for baseUrl
-
+    // if paths is defined, but no paths match
+    // then baseUrl will not fallback to "."
+    // if not using paths to find an alias, baseUrl must be defined
+    // so here we only try and resolve the file if baseUrl is explcitly set and valid
+    // i.e. if no baseUrl is provided
+    // then no imports relative to baseUrl on its own are allowed, only relative to paths
     if (validate.string(potentialBaseUrl)) {
         const resolvedFileLocation = path.resolve(
             configLocation,

--- a/src/utils/resolveAliasedImport.ts
+++ b/src/utils/resolveAliasedImport.ts
@@ -60,11 +60,13 @@ export const resolveAliasedImport = ({
 
     const potentialBaseUrl: unknown = config.config?.compilerOptions?.baseUrl;
 
-    const baseUrl = validate.string(potentialBaseUrl) ? potentialBaseUrl : '.';
-
     const configLocation = path.dirname(config.filepath);
 
     if (validate.tsconfigPaths(paths)) {
+        const baseUrl = validate.string(potentialBaseUrl)
+            ? potentialBaseUrl
+            : '.';
+
         for (const alias in paths) {
             const aliasRe = new RegExp(alias.replace('*', '(.+)'), '');
 
@@ -89,14 +91,18 @@ export const resolveAliasedImport = ({
     }
 
     // fallback to baseUrl
-    const resolvedFileLocation = path.resolve(
-        configLocation,
-        baseUrl,
-        importFilepath,
-    );
+    // if paths is not defined, don't use the fallback for baseUrl
 
-    if (fs.existsSync(resolvedFileLocation)) {
-        return resolvedFileLocation;
+    if (validate.string(potentialBaseUrl)) {
+        const resolvedFileLocation = path.resolve(
+            configLocation,
+            potentialBaseUrl,
+            importFilepath,
+        );
+
+        if (fs.existsSync(resolvedFileLocation)) {
+            return resolvedFileLocation;
+        }
     }
 
     return null;

--- a/src/utils/resolveAliasedImport.ts
+++ b/src/utils/resolveAliasedImport.ts
@@ -6,10 +6,6 @@ import {lilconfigSync} from 'lilconfig';
 const validate = {
     string: (x: unknown): x is string => typeof x === 'string',
     tsconfigPaths: (x: unknown): x is TsconfigPaths => {
-        if (x === undefined || x === null) {
-            return true;
-        }
-
         if (typeof x !== 'object' || x == null || Array.isArray(x)) {
             return false;
         }
@@ -28,7 +24,7 @@ const validate = {
     },
 };
 
-type TsconfigPaths = null | undefined | Record<string, string[]>;
+type TsconfigPaths = Record<string, string[]>;
 
 /**
  * Attempts to resolve aliased file paths using tsconfig or jsconfig
@@ -61,42 +57,38 @@ export const resolveAliasedImport = ({
     }
 
     const paths: unknown = config.config?.compilerOptions?.paths;
-    const baseUrl: unknown = config.config?.compilerOptions?.baseUrl;
+
+    const potentialBaseUrl: unknown = config.config?.compilerOptions?.baseUrl;
+
+    const baseUrl = validate.string(potentialBaseUrl) ? potentialBaseUrl : '.';
 
     const configLocation = path.dirname(config.filepath);
 
-    if (!validate.string(baseUrl)) {
-        return null;
-    }
+    if (validate.tsconfigPaths(paths)) {
+        for (const alias in paths) {
+            const aliasRe = new RegExp(alias.replace('*', '(.+)'), '');
 
-    if (!validate.tsconfigPaths(paths)) {
-        return null;
-    }
+            const aliasMatch = importFilepath.match(aliasRe);
 
-    for (const alias in paths) {
-        const aliasRe = new RegExp(alias.replace('*', '(.+)'), '');
+            if (aliasMatch == null) continue;
 
-        const aliasMatch = importFilepath.match(aliasRe);
+            for (const potentialAliasLocation of paths[alias]) {
+                const resolvedFileLocation = path.resolve(
+                    configLocation,
+                    baseUrl,
+                    potentialAliasLocation
+                        // "./utils/*" -> "./utils/style.module.css"
+                        .replace('*', aliasMatch[1]),
+                );
 
-        if (aliasMatch == null) continue;
+                if (!fs.existsSync(resolvedFileLocation)) continue;
 
-        for (const potentialAliasLocation of paths[alias]) {
-            const resolvedFileLocation = path.resolve(
-                configLocation,
-                baseUrl,
-                potentialAliasLocation
-                    // "./utils/*" -> "./utils/style.module.css"
-                    .replace('*', aliasMatch[1]),
-            );
-
-            if (!fs.existsSync(resolvedFileLocation)) continue;
-
-            return resolvedFileLocation;
+                return resolvedFileLocation;
+            }
         }
     }
 
-    // try to just use the baseUrl to resolve imports
-    // if not paths matched, still is a valid import
+    // fallback to baseUrl
     const resolvedFileLocation = path.resolve(
         configLocation,
         baseUrl,

--- a/src/utils/resolveAliasedImport.ts
+++ b/src/utils/resolveAliasedImport.ts
@@ -14,20 +14,17 @@ const validate = {
             return false;
         }
 
-        for (const key in x) {
-            const value =
-                // @ts-expect-error: here "key" can be used to index object
-                x[key];
-            if (
-                !Array.isArray(value) &&
-                value.length > 0 &&
-                !value.every(validate.string)
-            ) {
-                return false;
-            }
-        }
+        const paths = x as Record<string, unknown>;
 
-        return true;
+        const isValid = Object.values(paths).every(value => {
+            return (
+                Array.isArray(value) &&
+                value.length > 0 &&
+                value.every(validate.string)
+            );
+        });
+
+        return isValid;
     },
 };
 

--- a/src/utils/resolveAliasedImport.ts
+++ b/src/utils/resolveAliasedImport.ts
@@ -88,31 +88,20 @@ export const resolveAliasedImport = ({
                 return resolvedFileLocation;
             }
         }
+    }
 
-        // fallback to baseUrl of '.' only when paths are defined and valid
+    // fallback to baseUrl
+    // if paths is not defined, don't use the fallback for baseUrl
+
+    if (validate.string(potentialBaseUrl)) {
         const resolvedFileLocation = path.resolve(
             configLocation,
-            baseUrl,
+            potentialBaseUrl,
             importFilepath,
         );
 
         if (fs.existsSync(resolvedFileLocation)) {
             return resolvedFileLocation;
-        }
-    } else {
-        // no fallback to baseUrl of '.' if paths are not valid
-        // typescript only provides the '.' default when paths are set
-        // otherwise, no imports relative to project root (or baseUrl) are allowed
-        if (validate.string(potentialBaseUrl)) {
-            const resolvedFileLocation = path.resolve(
-                configLocation,
-                potentialBaseUrl,
-                importFilepath,
-            );
-
-            if (fs.existsSync(resolvedFileLocation)) {
-                return resolvedFileLocation;
-            }
         }
     }
 


### PR DESCRIPTION
Background: in a repo I use, we have `baseUrl: "."` set in the tsconfig.json, but without any `paths`. 

This allows us to import all of our files local to the project root, rather than relative imports throughout the project.

However, since we don't rely on the "paths" to alias our imports, then css module "Jump to Definition" functionality does not work, since it validates our tsconfig as having an invalid path.

This PR changes the validation logic so that it accepts null/undefined as a valid set of paths, since tsconfig works just fine when baseUrl is set, but no paths are set.

It also fixes an issue when validating the paths object, when it was in the shape of `Record<string, string>`, it would error out, as it tried to call `String.prototype.every` in the `validate.tsconfigPaths`, right after checking that `!Array.isArray`. This was slightly refactored, just to remove the ts-expect-error. 