### PR TITLE
fix duplicate drive path in windows

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,6 +3,7 @@ import {DocumentUri} from 'vscode-languageserver-textdocument';
 import path from 'path';
 import {EOL} from 'os';
 import fs from 'fs';
+import url from 'url';
 import _camelCase from 'lodash.camelcase';
 
 import postcss from 'postcss';
@@ -11,7 +12,8 @@ import type {Node, Parser, ProcessOptions, Comment} from 'postcss';
 import {resolveAliasedImport} from './utils/resolveAliasedImport';
 
 export function getCurrentDirFromUri(uri: DocumentUri) {
-    return path.dirname(uri).replace(/^file:\/\//, '');
+    const filePath = url.fileURLToPath(uri);
+    return path.dirname(filePath);
 }
 
 export type CamelCaseValues = false | true | 'dashes';


### PR DESCRIPTION
DocumentUri in windows comes in the format `file:///C:/path/folder/example.js`, when it's passed to `getCurrentDirFromUri`, the function returns `/C:/path/folder/` which after being passed to `path.resolve()` provokes the duplicated drive bug.

This PR replaces the manual convertion of uri to path with the nodeJS function url.fileURLToPath [documented here](https://nodejs.org/api/url.html#urlfileurltopathurl]) which has all filesystem differences covered.



Fixes #14 