### PR TITLE
Support comments in tsconfig files

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.3.1",
       "license": "MIT",
       "dependencies": {
+        "json5": "^2.2.3",
         "lilconfig": "^3.1.1",
         "lodash.camelcase": "^4.3.0",
         "postcss": "^8.1.10",
@@ -1570,6 +1571,17 @@
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
       "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
       "dev": true
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/jsonc-parser": {
       "version": "3.2.1",
@@ -3751,6 +3763,11 @@
       "resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
       "integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
       "dev": true
+    },
+    "json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="
     },
     "jsonc-parser": {
       "version": "3.2.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1706,9 +1706,12 @@
       }
     },
     "node_modules/minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/mlly": {
       "version": "1.6.1",
@@ -1761,15 +1764,6 @@
         "resolve": "^1.10.0",
         "semver": "2 || 3 || 4 || 5",
         "validate-npm-package-license": "^3.0.1"
-      }
-    },
-    "node_modules/normalize-package-data/node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver"
       }
     },
     "node_modules/npm-run-all": {
@@ -1879,15 +1873,6 @@
       "dev": true,
       "engines": {
         "node": ">=4"
-      }
-    },
-    "node_modules/npm-run-all/node_modules/semver": {
-      "version": "5.7.1",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-      "dev": true,
-      "bin": {
-        "semver": "bin/semver"
       }
     },
     "node_modules/npm-run-all/node_modules/shebang-command": {
@@ -2305,6 +2290,15 @@
         "@rollup/rollup-win32-ia32-msvc": "4.13.0",
         "@rollup/rollup-win32-x64-msvc": "4.13.0",
         "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/semver": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver"
       }
     },
     "node_modules/shebang-command": {
@@ -3861,9 +3855,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA=="
     },
     "mlly": {
       "version": "1.6.1",
@@ -3904,14 +3898,6 @@
         "resolve": "^1.10.0",
         "semver": "2 || 3 || 4 || 5",
         "validate-npm-package-license": "^3.0.1"
-      },
-      "dependencies": {
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-          "dev": true
-        }
       }
     },
     "npm-run-all": {
@@ -3995,12 +3981,6 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
           "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
-          "dev": true
-        },
-        "semver": {
-          "version": "5.7.1",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
           "dev": true
         },
         "shebang-command": {
@@ -4285,6 +4265,12 @@
         "@types/estree": "1.0.5",
         "fsevents": "~2.3.2"
       }
+    },
+    "semver": {
+      "version": "5.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.2.tgz",
+      "integrity": "sha512-cBznnQ9KjJqU67B52RMC65CMarK2600WFnbkcaiwWq3xy/5haFJlshgnpjovMVJ+Hff49d8GEn0b87C5pDQ10g==",
+      "dev": true
     },
     "shebang-command": {
       "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "vitest": "^1.4.0"
   },
   "dependencies": {
+    "json5": "^2.2.3",
     "lilconfig": "^3.1.1",
     "lodash.camelcase": "^4.3.0",
     "postcss": "^8.1.10",

--- a/src/spec/styles/tsconfig.json
+++ b/src/spec/styles/tsconfig.json
@@ -2,6 +2,7 @@
   "compilerOptions": {
     "baseUrl": ".",
     "paths": {
+      // @spec-styles points to this directory:
       "@spec-styles/*": [
         "*"
       ]

--- a/src/spec/styles/tsconfig.json
+++ b/src/spec/styles/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@spec-styles/*": [
+        "*"
+      ]
+    }
+  }
+}

--- a/src/spec/utils.spec.ts
+++ b/src/spec/utils.spec.ts
@@ -112,7 +112,8 @@ import sCss from './styles.scss'
 import sass from './styles.sass'
 import styl from './styles.styl'
 
-import aliasedCss from '@spec-styles/regular.css'
+import aliasedRegularCss from '@spec-styles/regular.css'
+import aliasedNestedSass from '@spec-styles/nested.sass'
 
 const rCss = require('./style.css')
 const rStyle = require('./style.css')
@@ -150,14 +151,17 @@ describe('findImportPath', () => {
         }),
     );
 
-    it('resolves aliased paths', () => {
-        const dirPath = path.join(__dirname, 'styles');
-        const importName = 'aliasedCss';
-        const expected = path.join(dirPath, 'regular.css');
+    const realDirPath = path.join(__dirname, 'styles');
 
-        const result = findImportPath(fileContent, importName, dirPath);
-        expect(result).toBe(expected);
-    })
+    [
+        ['aliasedRegularCss', path.join(realDirPath, 'regular.css')],
+        ['aliasedNestedSass', path.join(realDirPath, 'nested.sass')],
+    ].forEach(([importName, expected]) => {
+        it(`resolves aliased import path for ${importName}`, () => {
+            const result = findImportPath(fileContent, importName, realDirPath);
+            expect(result).toBe(expected);
+        })
+    });
 
     it('returns an empty string when there is no import', () => {
         const simpleComponentFile = [

--- a/src/spec/utils.spec.ts
+++ b/src/spec/utils.spec.ts
@@ -112,6 +112,8 @@ import sCss from './styles.scss'
 import sass from './styles.sass'
 import styl from './styles.styl'
 
+import aliasedCss from '@spec-styles/regular.css'
+
 const rCss = require('./style.css')
 const rStyle = require('./style.css')
 const rStyles = require('./styles.css')
@@ -147,6 +149,15 @@ describe('findImportPath', () => {
             expect(result).toBe(expected);
         }),
     );
+
+    it('resolves aliased paths', () => {
+        const dirPath = path.join(__dirname, 'styles');
+        const importName = 'aliasedCss';
+        const expected = path.join(dirPath, 'regular.css');
+
+        const result = findImportPath(fileContent, importName, dirPath);
+        expect(result).toBe(expected);
+    })
 
     it('returns an empty string when there is no import', () => {
         const simpleComponentFile = [

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -22,7 +22,7 @@ export function genImportRegExp(importName: string): RegExp {
     const file = '(.+\\.(styl|sass|scss|less|css))';
     const fromOrRequire = '(?:from\\s+|=\\s+require(?:<any>)?\\()';
     const requireEndOptional = '\\)?';
-    const pattern = `${importName}\\s+${fromOrRequire}["']${file}["']${requireEndOptional}`;
+    const pattern = `\\b${importName}\\s+${fromOrRequire}["']${file}["']${requireEndOptional}`;
 
     return new RegExp(pattern);
 }

--- a/src/utils/resolveAliasedImport.ts
+++ b/src/utils/resolveAliasedImport.ts
@@ -1,5 +1,6 @@
 import fs from 'fs';
 import path from 'path';
+import JSON5 from 'json5';
 
 import {lilconfigSync} from 'lilconfig';
 
@@ -49,6 +50,11 @@ export const resolveAliasedImport = ({
 }): string | null => {
     const searcher = lilconfigSync('', {
         searchPlaces: ['tsconfig.json', 'jsconfig.json'],
+        loaders: {
+            '.json': function(filepath, content) {
+                return JSON5.parse(content);
+            }
+        }
     });
     const config = searcher.search(location);
 


### PR DESCRIPTION
Per discussion in #23

Also includes a regex tweak because searching for the import path of `rCss` would also match something like `regularCss` (note the ending of the word). We can pull that out into a separate PR if you prefer, just have to tweak my tests here to not trigger that error.
