### PR TITLE
Support LSP actions in classes with dashes

### DIFF
--- a/src/CompletionProvider.ts
+++ b/src/CompletionProvider.ts
@@ -81,30 +81,26 @@ export class CSSModulesCompletionProvider {
         ).catch(() => []);
 
         const res = classNames.map(_class => {
-            // const name = this._classTransformer(_class);
-            const name = _class;
+            const name = this._classTransformer(_class);
 
-            const completionItem = CompletionItem.create(name);
+            let completionItem: CompletionItem;
 
-            // in case of items with dashes, we need to replace the `.` and add our field
+            // in case of items with dashes, we need to replace the `.` and suggest the field using the subscript expression
             if (name.includes('-')) {
-                completionItem.textEdit = lsp.InsertReplaceEdit.create(
-                    name,
-                    lsp.Range.create(
-                        lsp.Position.create(
-                            position.line,
-                            position.character - 1,
-                        ),
-                        position,
-                    ),
-                    lsp.Range.create(
-                        lsp.Position.create(
-                            position.line,
-                            position.character - 1,
-                        ),
-                        position,
-                    ),
+                const arrayAccessor = `['${name}']`;
+                const range = lsp.Range.create(
+                    lsp.Position.create(position.line, position.character - 1),
+                    position,
                 );
+
+                completionItem = CompletionItem.create(arrayAccessor);
+                completionItem.textEdit = lsp.InsertReplaceEdit.create(
+                    arrayAccessor,
+                    range,
+                    range,
+                );
+            } else {
+                completionItem = CompletionItem.create(name);
             }
             return completionItem;
         });

--- a/src/CompletionProvider.ts
+++ b/src/CompletionProvider.ts
@@ -81,9 +81,32 @@ export class CSSModulesCompletionProvider {
         ).catch(() => []);
 
         const res = classNames.map(_class => {
-            const name = this._classTransformer(_class);
+            // const name = this._classTransformer(_class);
+            const name = _class;
 
-            return CompletionItem.create(name);
+            const completionItem = CompletionItem.create(name);
+
+            // in case of items with dashes, we need to replace the `.` and add our field
+            if (name.includes('-')) {
+                completionItem.textEdit = lsp.InsertReplaceEdit.create(
+                    name,
+                    lsp.Range.create(
+                        lsp.Position.create(
+                            position.line,
+                            position.character - 1,
+                        ),
+                        position,
+                    ),
+                    lsp.Range.create(
+                        lsp.Position.create(
+                            position.line,
+                            position.character - 1,
+                        ),
+                        position,
+                    ),
+                );
+            }
+            return completionItem;
         });
 
         return res.map((x, i) => ({

--- a/src/DefinitionProvider.ts
+++ b/src/DefinitionProvider.ts
@@ -20,7 +20,7 @@ import {
     getTransformer,
     getWords,
     isImportLineMatch,
-    stringiyClassname,
+    stringifyClassname,
 } from './utils';
 
 export class CSSModulesDefinitionProvider {
@@ -87,7 +87,7 @@ export class CSSModulesDefinitionProvider {
         return {
             contents: {
                 language: 'css',
-                value: stringiyClassname(
+                value: stringifyClassname(
                     field,
                     node.declarations,
                     node.comments,

--- a/src/DefinitionProvider.ts
+++ b/src/DefinitionProvider.ts
@@ -65,12 +65,11 @@ export class CSSModulesDefinitionProvider {
         }
         const currentDir = getCurrentDirFromUri(textdocument.uri);
 
-        const words = getWords(currentLine, position);
-        if (words === '' || words.indexOf('.') === -1) {
+        const [obj, field] = getWords(currentLine, position);
+        if (obj === '') {
             return null;
         }
 
-        const [obj, field] = words.split('.');
         const importPath = findImportPath(fileContent, obj, currentDir);
         if (importPath === '') {
             return null;
@@ -123,12 +122,11 @@ export class CSSModulesDefinitionProvider {
             return Location.create(filePath, targetRange);
         }
 
-        const words = getWords(currentLine, position);
-        if (words === '' || words.indexOf('.') === -1) {
+        const [obj, field] = getWords(currentLine, position);
+        if (obj === '') {
             return null;
         }
 
-        const [obj, field] = words.split('.');
         const importPath = findImportPath(fileContent, obj, currentDir);
         if (importPath === '') {
             return null;

--- a/src/DefinitionProvider.ts
+++ b/src/DefinitionProvider.ts
@@ -65,10 +65,12 @@ export class CSSModulesDefinitionProvider {
         }
         const currentDir = getCurrentDirFromUri(textdocument.uri);
 
-        const [obj, field] = getWords(currentLine, position);
-        if (obj === '') {
+        const words = getWords(currentLine, position);
+        if (words === null) {
             return null;
         }
+
+        const [obj, field] = words;
 
         const importPath = findImportPath(fileContent, obj, currentDir);
         if (importPath === '') {
@@ -122,10 +124,12 @@ export class CSSModulesDefinitionProvider {
             return Location.create(filePath, targetRange);
         }
 
-        const [obj, field] = getWords(currentLine, position);
-        if (obj === '') {
+        const words = getWords(currentLine, position);
+        if (words === null) {
             return null;
         }
+
+        const [obj, field] = words;
 
         const importPath = findImportPath(fileContent, obj, currentDir);
         if (importPath === '') {

--- a/src/spec/resolveAliasedFilepath.spec.ts
+++ b/src/spec/resolveAliasedFilepath.spec.ts
@@ -26,7 +26,7 @@ vi.mock('fs', async () => {
     };
 });
 
-describe('utils: resolveAliaedFilepath', () => {
+describe('utils: resolveAliasedFilepath', () => {
     it('returns null if config does not exist', () => {
         (lilconfigSync as Mock).mockReturnValueOnce({
             search: () => null,

--- a/src/spec/utils.spec.ts
+++ b/src/spec/utils.spec.ts
@@ -1,9 +1,11 @@
 import * as path from 'path';
 import {describe, expect, it} from 'vitest';
+import {Position} from 'vscode-languageserver-protocol';
 import {
     filePathToClassnameDict,
     findImportPath,
     getTransformer,
+    getWords,
 } from '../utils';
 
 describe('filePathToClassnameDict', () => {
@@ -226,5 +228,35 @@ describe('getTransformer', () => {
 
             expect(result).toEqual(input);
         });
+    });
+});
+describe('getWords', () => {
+    it('returns null for a line with no .', () => {
+        const line = 'nostyles';
+        const position = Position.create(0, 1);
+        const result = getWords(line, position);
+
+        expect(result).toEqual(null);
+    });
+    it('returns pair of obj and field for line with property accessor expression', () => {
+        const line = 'styles.myclass';
+        const position = Position.create(0, 'styles.'.length);
+        const result = getWords(line, position);
+
+        expect(result).toEqual(['styles', 'myclass']);
+    });
+    it('returns pair of obj and field for line with subscript accessor expression (single quoted)', () => {
+        const line = "styles['myclass']";
+        const position = Position.create(0, "styles['".length);
+        const result = getWords(line, position);
+
+        expect(result).toEqual(['styles', 'myclass']);
+    });
+    it('returns pair of obj and field for line with subscript accessor expression (double quoted)', () => {
+        const line = 'styles["myclass"]';
+        const position = Position.create(0, 'styles["'.length);
+        const result = getWords(line, position);
+
+        expect(result).toEqual(['styles', 'myclass']);
     });
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -137,7 +137,7 @@ export function getWords(
     // not found or not clicking object field
     if (startIndex === -1 || headText.slice(startIndex).indexOf('.') === -1) {
         // check if this is a subscript expression instead
-        const startIndex = headText.search(/[a-z0-9'_\[\-]*$/i);
+        const startIndex = headText.search(/[a-z0-9"'_\[\-]*$/i);
         if (
             startIndex === -1 ||
             headText.slice(startIndex).indexOf('[') === -1
@@ -145,7 +145,7 @@ export function getWords(
             return null;
         }
 
-        const match = /^([a-z0-9_\-\[']*)/i.exec(line.slice(startIndex));
+        const match = /^([a-z0-9_\-\['"]*)/i.exec(line.slice(startIndex));
         if (match === null) {
             return null;
         }
@@ -153,10 +153,9 @@ export function getWords(
         const [styles, className] = match[1].split('[');
 
         // remove wrapping quotes around class name (both `'` or `"`)
-        return [styles, className.substring(1, className.length - 1)] as [
-            string,
-            string,
-        ];
+        const unwrappedName = className.substring(1, className.length - 1);
+
+        return [styles, unwrappedName] as [string, string];
     }
 
     const match = /^([a-z0-9\._]*)/i.exec(line.slice(startIndex));

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -128,7 +128,10 @@ export async function getPosition(
         : null;
 }
 
-export function getWords(line: string, position: Position): [string, string] {
+export function getWords(
+    line: string,
+    position: Position,
+): [string, string] | null {
     const headText = line.slice(0, position.character);
     const startIndex = headText.search(/[a-z0-9\._]*$/i);
     // not found or not clicking object field
@@ -139,12 +142,12 @@ export function getWords(line: string, position: Position): [string, string] {
             startIndex === -1 ||
             headText.slice(startIndex).indexOf('[') === -1
         ) {
-            return ['', ''];
+            return null;
         }
 
         const match = /^([a-z0-9_\-\[']*)/i.exec(line.slice(startIndex));
         if (match === null) {
-            return ['', ''];
+            return null;
         }
 
         const [styles, className] = match[1].split('[');
@@ -158,7 +161,7 @@ export function getWords(line: string, position: Position): [string, string] {
 
     const match = /^([a-z0-9\._]*)/i.exec(line.slice(startIndex));
     if (match === null) {
-        return ['', ''];
+        return null;
     }
 
     return match[1].split('.') as [string, string];

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -86,7 +86,8 @@ export function getTransformer(
                     firstLetter.toUpperCase(),
                 );
         default:
-            return x => x;
+            return str =>
+                str.includes('-') ? `.['${str.substring(1)}']` : str;
     }
 }
 
@@ -128,20 +129,34 @@ export async function getPosition(
         : null;
 }
 
-export function getWords(line: string, position: Position): string {
+export function getWords(line: string, position: Position): [string, string] {
     const headText = line.slice(0, position.character);
     const startIndex = headText.search(/[a-z0-9\._]*$/i);
     // not found or not clicking object field
     if (startIndex === -1 || headText.slice(startIndex).indexOf('.') === -1) {
-        return '';
+        const startIndex = headText.search(/[a-z0-9'_\[\-]*$/i);
+        if (
+            startIndex === -1 ||
+            headText.slice(startIndex).indexOf('[') === -1
+        ) {
+            return ['', ''];
+        }
+
+        const match = /^([a-z0-9_\-\[']*)/i.exec(line.slice(startIndex));
+        if (match === null) {
+            return ['', ''];
+        }
+
+        const [a, b] = match[1].split('[');
+        return [a, `[${b}]`] as [string, string];
     }
 
     const match = /^([a-z0-9\._]*)/i.exec(line.slice(startIndex));
     if (match === null) {
-        return '';
+        return ['', ''];
     }
 
-    return match[1];
+    return match[1].split('.') as [string, string];
 }
 
 type ClassnamePostion = {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -86,8 +86,7 @@ export function getTransformer(
                     firstLetter.toUpperCase(),
                 );
         default:
-            return str =>
-                str.includes('-') ? `.['${str.substring(1)}']` : str;
+            return x => x;
     }
 }
 
@@ -134,6 +133,7 @@ export function getWords(line: string, position: Position): [string, string] {
     const startIndex = headText.search(/[a-z0-9\._]*$/i);
     // not found or not clicking object field
     if (startIndex === -1 || headText.slice(startIndex).indexOf('.') === -1) {
+        // check if this is a subscript expression instead
         const startIndex = headText.search(/[a-z0-9'_\[\-]*$/i);
         if (
             startIndex === -1 ||
@@ -147,8 +147,13 @@ export function getWords(line: string, position: Position): [string, string] {
             return ['', ''];
         }
 
-        const [a, b] = match[1].split('[');
-        return [a, `[${b}]`] as [string, string];
+        const [styles, className] = match[1].split('[');
+
+        // remove wrapping quotes around class name (both `'` or `"`)
+        return [styles, className.substring(1, className.length - 1)] as [
+            string,
+            string,
+        ];
     }
 
     const match = /^([a-z0-9\._]*)/i.exec(line.slice(startIndex));
@@ -416,7 +421,7 @@ export async function getAllClassNames(
         : classList;
 }
 
-export function stringiyClassname(
+export function stringifyClassname(
     classname: string,
     declarations: string[],
     comments: string[],


### PR DESCRIPTION
Hi, first of all thanks for working on this LSP as it's been quite useful while developing and consuming CSS modules from TS code. Sorry in advance as I have not created an issue previously for this and went ahead with this PR.

### Issue
When using CSS class names with dashes (e.g. `.class-name`) and `camelCase = false` configured some feats don't work as expected:
- Completion provider suggests `.class-name` resulting in this property expression `styles.class-name`, which does not compile in a typical Typescript project
- Hover and definition providers are not able to find the class definition when using the subscript expression to access the class mentioned (i.e. `styles['class-name']`)

This PR includes:
- Adds completion insert replace information when the class name includes `-` in the name, to use the subscript expression and replace the `.` that triggered the completion for those specific classes
- Refactor of the `utils#getWords` function to be able to parse the subscript expressions in the code for correct identification of the class name when using hover and definition features
- Tests for the above mentioned refactor