### PR TITLE
feat: bracket completion trigger

### DIFF
--- a/src/CompletionProvider.ts
+++ b/src/CompletionProvider.ts
@@ -159,9 +159,6 @@ export class CSSModulesCompletionProvider {
             const completionField =
                 trigger === '[' || nameIncludesDashes ? `['${name}']` : name;
 
-            // FIXME - avoid extra ] at the end - moliva - 2024/04/08
-            // FIXME - when adding quotes ' or " it won't suggest anything - moliva - 2024/04/08
-
             let completionItem: CompletionItem;
             // in case of items with dashes, we need to replace the `.` and suggest the field using the subscript expression `[`
             if (trigger === '.') {

--- a/src/CompletionProvider.ts
+++ b/src/CompletionProvider.ts
@@ -11,34 +11,43 @@ import {
 } from './utils';
 import type {CamelCaseValues} from './utils';
 
-export const COMPLETION_TRIGGERS = ['.', '['] as const;
+export const COMPLETION_TRIGGERS = ['.', '[', '"', "'"] as const;
+
+type FieldOptions = {
+    wrappingBracket: boolean;
+    startsWithQuote: boolean;
+    endsWithQuote: boolean;
+};
 
 /**
- * check if current character or last character is any of the completion triggers (i.e. `.`, `[`)
+ * check if current character or last character is any of the completion triggers (i.e. `.`, `[`) and return it
  *
  * @see COMPLETION_TRIGGERS
  */
-function findTrigger(
-    line: string,
-    position: Position,
-): [string, number] | undefined {
+function findTrigger(line: string, position: Position): string | undefined {
     const i = position.character - 1;
 
     for (const trigger of COMPLETION_TRIGGERS) {
         if (line[i] === trigger) {
-            return [trigger, i];
+            return trigger;
         }
         if (i > 1 && line[i - 1] === trigger) {
-            return [trigger, i - 1];
+            return trigger;
         }
     }
+
     return undefined;
 }
 
+/**
+ * Given the line, position and trigger, returns the identifier referencing the styles spreadsheet and the (partial) field selected with options to help construct the completion item later.
+ *
+ * @returns
+ */
 function getWords(
     line: string,
     position: Position,
-    [trigger]: [string, number],
+    trigger: string,
 ): [string, string, FieldOptions?] | undefined {
     const text = line.slice(0, position.character);
     const index = text.search(/[a-z0-9\._\[\]'"\-]*$/i);
@@ -52,49 +61,86 @@ function getWords(
         return undefined;
     }
 
-    // process `.` trigger
-    if (trigger === '.') {
-        return words.split('.') as [string, string];
+    switch (trigger) {
+        // process `.` trigger
+        case '.':
+            return words.split('.') as [string, string];
+        // process `[` trigger
+        default: {
+            const [obj, field] = words.split('[');
+
+            let lineAhead = line.slice(position.character);
+            const endsWithQuote = lineAhead.search(/^["']/) !== -1;
+
+            lineAhead = endsWithQuote ? lineAhead.slice(1) : lineAhead;
+            const wrappingBracket = lineAhead.search(/^\s*\]/) !== -1;
+
+            const startsWithQuote =
+                field.length > 0 && (field[0] === '"' || field[0] === "'");
+
+            return [
+                obj,
+                field.slice(startsWithQuote ? 1 : 0),
+                {wrappingBracket, startsWithQuote, endsWithQuote},
+            ];
+        }
     }
-
-    // process `[` trigger
-    const [obj, field] = words.split('[');
-
-    return [obj, ...trimQuotes(field)];
 }
 
-type FieldOptions = {
-    wrappingBracket: boolean;
-    startsWithQuote: string | false;
-    endsWithQuote: string | false;
-};
+function createCompletionItem(
+    trigger: string,
+    name: string,
+    position: Position,
+    fieldOptions: FieldOptions | undefined,
+): CompletionItem {
+    const nameIncludesDashes = name.includes('-');
+    const completionField =
+        trigger === '[' || nameIncludesDashes ? `['${name}']` : name;
 
-function trimQuotes(field: string): [string, FieldOptions] {
-    let _field = field;
+    let completionItem: CompletionItem;
+    // in case of items with dashes, we need to replace the `.` and suggest the field using the subscript expression `[`
+    if (trigger === '.') {
+        if (nameIncludesDashes) {
+            const range = lsp.Range.create(
+                lsp.Position.create(position.line, position.character - 1), // replace the `.` character
+                position,
+            );
 
-    const wrappingBracket = _field[_field.length - 1] === ']';
-    if (wrappingBracket) {
-        _field = _field.slice(0, _field.length - 1);
+            completionItem = CompletionItem.create(completionField);
+            completionItem.textEdit = lsp.InsertReplaceEdit.create(
+                completionField,
+                range,
+                range,
+            );
+        } else {
+            completionItem = CompletionItem.create(completionField);
+        }
+    } else {
+        // trigger === '['
+        const startPositionCharacter =
+            position.character -
+            1 - // replace the `[` character
+            (fieldOptions?.startsWithQuote ? 1 : 0); // replace the starting quote if present
+
+        const endPositionCharacter =
+            position.character +
+            (fieldOptions?.endsWithQuote ? 1 : 0) + // replace the ending quote if present
+            (fieldOptions?.wrappingBracket ? 1 : 0); // replace the wrapping bracket if present
+
+        const range = lsp.Range.create(
+            lsp.Position.create(position.line, startPositionCharacter),
+            lsp.Position.create(position.line, endPositionCharacter),
+        );
+
+        completionItem = CompletionItem.create(completionField);
+        completionItem.textEdit = lsp.InsertReplaceEdit.create(
+            completionField,
+            range,
+            range,
+        );
     }
 
-    const startsWithQuote =
-        _field.length > 0 && (_field[0] === '"' || _field[0] === "'")
-            ? _field[0]
-            : false;
-
-    const endsWithQuote =
-        _field.length > 1 && // must be > 1 to avoid checking same char as the `startsWithQuote`
-        (_field[_field.length - 1] === '"' || _field[_field.length - 1] === "'")
-            ? _field[_field.length - 1]
-            : false;
-
-    return [
-        _field.slice(
-            startsWithQuote ? 1 : 0,
-            endsWithQuote ? _field.length - 1 : _field.length,
-        ),
-        {wrappingBracket, startsWithQuote, endsWithQuote},
-    ];
+    return completionItem;
 }
 
 export class CSSModulesCompletionProvider {
@@ -127,12 +173,12 @@ export class CSSModulesCompletionProvider {
         if (typeof currentLine !== 'string') return null;
         const currentDir = getCurrentDirFromUri(textdocument.uri);
 
-        const foundTrigger = findTrigger(currentLine, position);
-        if (!foundTrigger) {
+        const trigger = findTrigger(currentLine, position);
+        if (!trigger) {
             return [];
         }
 
-        const foundFields = getWords(currentLine, position, foundTrigger);
+        const foundFields = getWords(currentLine, position, trigger);
         if (!foundFields) {
             return [];
         }
@@ -153,58 +199,12 @@ export class CSSModulesCompletionProvider {
         const res = classNames.map(_class => {
             const name = this._classTransformer(_class);
 
-            const [trigger] = foundTrigger;
-
-            const nameIncludesDashes = name.includes('-');
-            const completionField =
-                trigger === '[' || nameIncludesDashes ? `['${name}']` : name;
-
-            let completionItem: CompletionItem;
-            // in case of items with dashes, we need to replace the `.` and suggest the field using the subscript expression `[`
-            if (trigger === '.') {
-                if (nameIncludesDashes) {
-                    const range = lsp.Range.create(
-                        lsp.Position.create(
-                            position.line,
-                            position.character - 1,
-                        ),
-                        position,
-                    );
-
-                    completionItem = CompletionItem.create(completionField);
-                    completionItem.textEdit = lsp.InsertReplaceEdit.create(
-                        completionField,
-                        range,
-                        range,
-                    );
-                } else {
-                    completionItem = CompletionItem.create(completionField);
-                }
-            } else {
-                // trigger === '['
-                const range = lsp.Range.create(
-                    lsp.Position.create(
-                        position.line,
-                        position.character -
-                            1 -
-                            (fieldOptions?.startsWithQuote ? 1 : 0),
-                    ),
-                    lsp.Position.create(
-                        position.line,
-                        position.character +
-                            1 +
-                            +(fieldOptions?.endsWithQuote ? 1 : 0) +
-                            (fieldOptions?.wrappingBracket ? 1 : 0),
-                    ),
-                );
-
-                completionItem = CompletionItem.create(completionField);
-                completionItem.textEdit = lsp.InsertReplaceEdit.create(
-                    completionField,
-                    range,
-                    range,
-                );
-            }
+            const completionItem = createCompletionItem(
+                trigger,
+                name,
+                position,
+                fieldOptions,
+            );
 
             return completionItem;
         });

--- a/src/CompletionProvider.ts
+++ b/src/CompletionProvider.ts
@@ -42,7 +42,6 @@ function findTrigger(line: string, position: Position): string | undefined {
 /**
  * Given the line, position and trigger, returns the identifier referencing the styles spreadsheet and the (partial) field selected with options to help construct the completion item later.
  *
- * @returns
  */
 function getWords(
     line: string,
@@ -66,7 +65,7 @@ function getWords(
         case '.':
             return words.split('.') as [string, string];
         // process `[` trigger
-        default: {
+        case '[': {
             const [obj, field] = words.split('[');
 
             let lineAhead = line.slice(position.character);
@@ -83,6 +82,9 @@ function getWords(
                 field.slice(startsWithQuote ? 1 : 0),
                 {wrappingBracket, startsWithQuote, endsWithQuote},
             ];
+        }
+        default: {
+          throw new Error(`Unsupported trigger character ${trigger}`);
         }
     }
 }

--- a/src/CompletionProvider.ts
+++ b/src/CompletionProvider.ts
@@ -11,20 +11,90 @@ import {
 } from './utils';
 import type {CamelCaseValues} from './utils';
 
-// check if current character or last character is .
-function isTrigger(line: string, position: Position): boolean {
+export const COMPLETION_TRIGGERS = ['.', '['] as const;
+
+/**
+ * check if current character or last character is any of the completion triggers (i.e. `.`, `[`)
+ *
+ * @see COMPLETION_TRIGGERS
+ */
+function findTrigger(
+    line: string,
+    position: Position,
+): [string, number] | undefined {
     const i = position.character - 1;
-    return line[i] === '.' || (i > 1 && line[i - 1] === '.');
+
+    for (const trigger of COMPLETION_TRIGGERS) {
+        if (line[i] === trigger) {
+            return [trigger, i];
+        }
+        if (i > 1 && line[i - 1] === trigger) {
+            return [trigger, i - 1];
+        }
+    }
+    return undefined;
 }
 
-function getWords(line: string, position: Position): string {
+function getWords(
+    line: string,
+    position: Position,
+    [trigger]: [string, number],
+): [string, string, FieldOptions?] | undefined {
     const text = line.slice(0, position.character);
-    const index = text.search(/[a-z0-9\._]*$/i);
+    const index = text.search(/[a-z0-9\._\[\]'"\-]*$/i);
     if (index === -1) {
-        return '';
+        return undefined;
     }
 
-    return text.slice(index);
+    const words = text.slice(index);
+
+    if (words === '' || words.indexOf(trigger) === -1) {
+        return undefined;
+    }
+
+    // process `.` trigger
+    if (trigger === '.') {
+        return words.split('.') as [string, string];
+    }
+
+    // process `[` trigger
+    const [obj, field] = words.split('[');
+
+    return [obj, ...trimQuotes(field)];
+}
+
+type FieldOptions = {
+    wrappingBracket: boolean;
+    startsWithQuote: string | false;
+    endsWithQuote: string | false;
+};
+
+function trimQuotes(field: string): [string, FieldOptions] {
+    let _field = field;
+
+    const wrappingBracket = _field[_field.length - 1] === ']';
+    if (wrappingBracket) {
+        _field = _field.slice(0, _field.length - 1);
+    }
+
+    const startsWithQuote =
+        _field.length > 0 && (_field[0] === '"' || _field[0] === "'")
+            ? _field[0]
+            : false;
+
+    const endsWithQuote =
+        _field.length > 1 && // must be > 1 to avoid checking same char as the `startsWithQuote`
+        (_field[_field.length - 1] === '"' || _field[_field.length - 1] === "'")
+            ? _field[_field.length - 1]
+            : false;
+
+    return [
+        _field.slice(
+            startsWithQuote ? 1 : 0,
+            endsWithQuote ? _field.length - 1 : _field.length,
+        ),
+        {wrappingBracket, startsWithQuote, endsWithQuote},
+    ];
 }
 
 export class CSSModulesCompletionProvider {
@@ -57,17 +127,17 @@ export class CSSModulesCompletionProvider {
         if (typeof currentLine !== 'string') return null;
         const currentDir = getCurrentDirFromUri(textdocument.uri);
 
-        if (!isTrigger(currentLine, position)) {
+        const foundTrigger = findTrigger(currentLine, position);
+        if (!foundTrigger) {
             return [];
         }
 
-        const words = getWords(currentLine, position);
-
-        if (words === '' || words.indexOf('.') === -1) {
+        const foundFields = getWords(currentLine, position, foundTrigger);
+        if (!foundFields) {
             return [];
         }
 
-        const [obj, field] = words.split('.');
+        const [obj, field, fieldOptions] = foundFields;
 
         const importPath = findImportPath(fileContent, obj, currentDir);
         if (importPath === '') {
@@ -83,25 +153,62 @@ export class CSSModulesCompletionProvider {
         const res = classNames.map(_class => {
             const name = this._classTransformer(_class);
 
+            const [trigger] = foundTrigger;
+
+            const nameIncludesDashes = name.includes('-');
+            const completionField =
+                trigger === '[' || nameIncludesDashes ? `['${name}']` : name;
+
+            // FIXME - avoid extra ] at the end - moliva - 2024/04/08
+            // FIXME - when adding quotes ' or " it won't suggest anything - moliva - 2024/04/08
+
             let completionItem: CompletionItem;
+            // in case of items with dashes, we need to replace the `.` and suggest the field using the subscript expression `[`
+            if (trigger === '.') {
+                if (nameIncludesDashes) {
+                    const range = lsp.Range.create(
+                        lsp.Position.create(
+                            position.line,
+                            position.character - 1,
+                        ),
+                        position,
+                    );
 
-            // in case of items with dashes, we need to replace the `.` and suggest the field using the subscript expression
-            if (name.includes('-')) {
-                const arrayAccessor = `['${name}']`;
-                const range = lsp.Range.create(
-                    lsp.Position.create(position.line, position.character - 1),
-                    position,
-                );
-
-                completionItem = CompletionItem.create(arrayAccessor);
-                completionItem.textEdit = lsp.InsertReplaceEdit.create(
-                    arrayAccessor,
-                    range,
-                    range,
-                );
+                    completionItem = CompletionItem.create(completionField);
+                    completionItem.textEdit = lsp.InsertReplaceEdit.create(
+                        completionField,
+                        range,
+                        range,
+                    );
+                } else {
+                    completionItem = CompletionItem.create(completionField);
+                }
             } else {
-                completionItem = CompletionItem.create(name);
+                // trigger === '['
+                const range = lsp.Range.create(
+                    lsp.Position.create(
+                        position.line,
+                        position.character -
+                            1 -
+                            (fieldOptions?.startsWithQuote ? 1 : 0),
+                    ),
+                    lsp.Position.create(
+                        position.line,
+                        position.character +
+                            1 +
+                            +(fieldOptions?.endsWithQuote ? 1 : 0) +
+                            (fieldOptions?.wrappingBracket ? 1 : 0),
+                    ),
+                );
+
+                completionItem = CompletionItem.create(completionField);
+                completionItem.textEdit = lsp.InsertReplaceEdit.create(
+                    completionField,
+                    range,
+                    range,
+                );
             }
+
             return completionItem;
         });
 

--- a/src/CompletionProvider.ts
+++ b/src/CompletionProvider.ts
@@ -11,7 +11,7 @@ import {
 } from './utils';
 import type {CamelCaseValues} from './utils';
 
-export const COMPLETION_TRIGGERS = ['.', '[', '"', "'"] as const;
+export const COMPLETION_TRIGGERS = ['.', '[', '"', "'"];
 
 type FieldOptions = {
     wrappingBracket: boolean;

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -1,6 +1,9 @@
 import * as lsp from 'vscode-languageserver/node';
 
-import {CSSModulesCompletionProvider} from './CompletionProvider';
+import {
+    COMPLETION_TRIGGERS,
+    CSSModulesCompletionProvider,
+} from './CompletionProvider';
 import {CSSModulesDefinitionProvider} from './DefinitionProvider';
 import {textDocuments} from './textDocuments';
 
@@ -42,9 +45,9 @@ export function createConnection(): lsp.Connection {
                 implementationProvider: true,
                 completionProvider: {
                     /**
-                     * only invoke completion once `.` is pressed
+                     * only invoke completion once `.` or `[` are pressed
                      */
-                    triggerCharacters: ['.'],
+                    triggerCharacters: COMPLETION_TRIGGERS.slice(),
                     resolveProvider: true,
                 },
             },

--- a/src/connection.ts
+++ b/src/connection.ts
@@ -47,7 +47,7 @@ export function createConnection(): lsp.Connection {
                     /**
                      * only invoke completion once `.` or `[` are pressed
                      */
-                    triggerCharacters: COMPLETION_TRIGGERS.slice(),
+                    triggerCharacters: COMPLETION_TRIGGERS,
                     resolveProvider: true,
                 },
             },


### PR DESCRIPTION
This is an extension to #25.

Introduces `[` as a trigger character for completion, managing replacements avoiding to add wrapping characters if already present in file contents (mostly due to automatic edit tools completion).