### PR TITLE
chore: change CompletionItemKind to `Field`

### DIFF
--- a/src/CompletionProvider.ts
+++ b/src/CompletionProvider.ts
@@ -213,7 +213,7 @@ export class CSSModulesCompletionProvider {
 
         return res.map((x, i) => ({
             ...x,
-            kind: lsp.CompletionItemKind.Text,
+            kind: lsp.CompletionItemKind.Field,
             data: i + 1,
         }));
     }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/dc1a6085-3418-4301-a476-f0f5f5c1473a)

The original `Text` type is confusing (only `title` is actually the real class name in the picture, the rest are just normal words for the current file) 