### PR TITLE
feat: inherited import aliases in tsconfig

### DIFF
--- a/src/utils/resolveJson5File.ts
+++ b/src/utils/resolveJson5File.ts
@@ -1,0 +1,36 @@
+import fs from 'fs';
+import JSON5 from 'json5';
+
+import type {LilconfigResult} from 'lilconfig';
+
+/**
+ * Attempts to resolve the path to a json5 file using node.js resolution rules
+ *
+ * returns null if file could not be resolved, or if JSON5 parsing fails
+ * @see https://www.typescriptlang.org/tsconfig/#extends
+ */
+export const resolveJson5File = ({
+    path,
+    base,
+}: {
+    /**
+     * path to the json5 file
+     * @example "../tsconfig.json"
+     */
+    path: string;
+    /**
+     * directory where the file with import is located
+     * @example "/Users/foo/project/components"
+     */
+    base: string;
+}): LilconfigResult => {
+    try {
+        const filepath = require.resolve(path, {paths: [base]});
+        const content = fs.readFileSync(filepath, 'utf8');
+        const isEmpty = content.trim() === '';
+        const config = isEmpty ? {} : JSON5.parse(content);
+        return {filepath, isEmpty, config};
+    } catch (e) {
+        return null;
+    }
+};


### PR DESCRIPTION
This PR adds support for `paths` (and `baseUrl`) that are defined in a parent `tsconfig.json`, linked using the `extends` field. I came across this issue because this is the default setup for [nx](https://nx.dev) projects.

The PR adds node.js style resolution of the `extends` field, and guards against infinite `extends` loops. I pulled `resolveJson5File` out into a separate file as it seems `require.resolve` is pretty impossible to mock for the tests.  The PR changes the logic to eagerly resolve `baseUrl` into an absolute path, as the value is always relative to whichever config file it was defined in.

I tested using this nx template which uses a parent tsconfig to import the util styles: https://github.com/domharries/cssmodules-nx-example/blob/main/apps/cssmodules-nx-example/src/app/app.tsx