### PR TITLE
feat: rage command

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -9,4 +9,20 @@ if (args.includes('--version') || args.includes('-v')) {
     process.exit(0);
 }
 
+if (args.includes('rage')) {
+    const environment = {
+        Platform: process.platform,
+        Arch: process.arch,
+        NodeVersion: process.version,
+        NodePath: process.execPath,
+        CssModulesLanguageServerVersion: require('../package.json').version,
+    };
+
+    Object.entries(environment).forEach(([key, value]) => {
+        process.stdout.write(`${key}: ${value}\n`);
+    });
+
+    process.exit(0);
+}
+
 createConnection().listen();


### PR DESCRIPTION
This command can be used to obtain environment information to trouble shoot user issues 

Example output
```
▲ node ./lib/cli.js rage     
Platform: darwin
Arch: arm64
NodeVersion: v23.6.1
NodePath: /opt/homebrew/Cellar/node/23.6.1/bin/node
CssModulesLanguageServerVersion: 1.5.1
```