### PR TITLE
add support for atrules with class selectors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -807,6 +807,20 @@
         "linux"
       ]
     },
+    "node_modules/@rollup/rollup-linux-powerpc64le-gnu": {
+      "version": "4.32.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.32.0.tgz",
+      "integrity": "sha512-Sts5DST1jXAc9YH/iik1C9QRsLcCoOScf3dfbY5i4kH9RJpKxiTBXqm7qU5O6zTXBTEZry69bGszr3SMgYmMcQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
     "node_modules/@rollup/rollup-linux-riscv64-gnu": {
       "version": "4.32.0",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.32.0.tgz",
@@ -933,6 +947,7 @@
       "integrity": "sha512-wI8uHusga+0ZugNp0Ol/3BqQfEcCCNfojtO6Oou9iVNGPTL6QNSdnUdqq85fRgIorLhLMuPIKpsN98QE9Nh+KQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~5.26.4"
       }
@@ -1562,6 +1577,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.7",
         "picocolors": "^1.1.1",
@@ -1915,6 +1931,7 @@
       "integrity": "sha512-4VL9mQPKoHy4+FE0NnRE/kbY51TOfaknxAjt3fJbGJxhIpBZiqVzlZDEesWWsuREXHwNdAoOFZ9MkPEVXczHwg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "esbuild": "^0.24.2",
         "postcss": "^8.4.49",
@@ -2607,6 +2624,13 @@
       "dev": true,
       "optional": true
     },
+    "@rollup/rollup-linux-powerpc64le-gnu": {
+      "version": "4.32.0",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-powerpc64le-gnu/-/rollup-linux-powerpc64le-gnu-4.32.0.tgz",
+      "integrity": "sha512-Sts5DST1jXAc9YH/iik1C9QRsLcCoOScf3dfbY5i4kH9RJpKxiTBXqm7qU5O6zTXBTEZry69bGszr3SMgYmMcQ==",
+      "dev": true,
+      "optional": true
+    },
     "@rollup/rollup-linux-riscv64-gnu": {
       "version": "4.32.0",
       "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.32.0.tgz",
@@ -2682,6 +2706,7 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.67.tgz",
       "integrity": "sha512-wI8uHusga+0ZugNp0Ol/3BqQfEcCCNfojtO6Oou9iVNGPTL6QNSdnUdqq85fRgIorLhLMuPIKpsN98QE9Nh+KQ==",
       "dev": true,
+      "peer": true,
       "requires": {
         "undici-types": "~5.26.4"
       }
@@ -3088,6 +3113,7 @@
       "version": "8.4.49",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.49.tgz",
       "integrity": "sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==",
+      "peer": true,
       "requires": {
         "nanoid": "^3.3.7",
         "picocolors": "^1.1.1",
@@ -3316,6 +3342,7 @@
       "resolved": "https://registry.npmjs.org/vite/-/vite-6.0.11.tgz",
       "integrity": "sha512-4VL9mQPKoHy4+FE0NnRE/kbY51TOfaknxAjt3fJbGJxhIpBZiqVzlZDEesWWsuREXHwNdAoOFZ9MkPEVXczHwg==",
       "dev": true,
+      "peer": true,
       "requires": {
         "esbuild": "^0.24.2",
         "fsevents": "~2.3.3",

--- a/src/spec/__snapshots__/utils.spec.ts.snap
+++ b/src/spec/__snapshots__/utils.spec.ts.snap
@@ -809,3 +809,75 @@ exports[`filePathToClassnameDict > SCSS > gets a dictionary of nested classnames
   },
 }
 `;
+
+exports[`filePathToClassnameDict > SCSS > infers class definitions inside layers 1`] = `
+{
+  ".container": {
+    "comments": [],
+    "declarations": [
+      "max-width: 1528px;",
+      "margin: 0 auto;",
+      "padding: 0 60px;",
+    ],
+    "position": {
+      "column": 3,
+      "line": 2,
+    },
+  },
+  ".in_container": {
+    "comments": [],
+    "declarations": [
+      "font-size: 1.2rem;",
+      "padding: 20px;",
+    ],
+    "position": {
+      "column": 3,
+      "line": 27,
+    },
+  },
+  ".in_document": {
+    "comments": [],
+    "declarations": [
+      "color: green;",
+    ],
+    "position": {
+      "column": 3,
+      "line": 14,
+    },
+  },
+  ".in_media": {
+    "comments": [],
+    "declarations": [
+      "background-color: #121212;",
+      "color: #e0e0e0;",
+    ],
+    "position": {
+      "column": 3,
+      "line": 20,
+    },
+  },
+  ".in_scope": {
+    "comments": [],
+    "declarations": [
+      "border: 2px solid blue;",
+      "padding: 10px;",
+    ],
+    "position": {
+      "column": 3,
+      "line": 34,
+    },
+  },
+  ".in_supports": {
+    "comments": [],
+    "declarations": [
+      "display: grid;",
+      "grid-template-columns: repeat(3, 1fr);",
+      "gap: 20px;",
+    ],
+    "position": {
+      "column": 3,
+      "line": 47,
+    },
+  },
+}
+`;

--- a/src/spec/styles/atrules.scss
+++ b/src/spec/styles/atrules.scss
@@ -1,0 +1,52 @@
+@layer base {
+  .container {
+    max-width: 1528px;
+    margin: 0 auto;
+    padding: 0 60px;
+
+    @media (max-width: 767px) {
+      padding: 0 20px;
+    }
+  }
+}
+
+@document url("https://www.example.com/") {
+  .in_document {
+    color: green;
+  }
+}
+
+@media (prefers-color-scheme: dark) {
+  .in_media {
+    background-color: #121212;
+    color: #e0e0e0;
+  }
+}
+
+@container (width >=600px) {
+  .in_container {
+    font-size: 1.2rem;
+    padding: 20px;
+  }
+}
+
+@scope (.scoped) {
+  .in_scope {
+    border: 2px solid blue;
+    padding: 10px;
+  }
+}
+
+@starting-state (hover) {
+  .in_starting_state:hover {
+    background-color: yellow;
+  }
+}
+
+@supports (display: grid) {
+  .in_supports {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 20px;
+  }
+}

--- a/src/spec/utils.spec.ts
+++ b/src/spec/utils.spec.ts
@@ -87,6 +87,16 @@ describe('filePathToClassnameDict', () => {
 
             expect(result).toMatchSnapshot();
         });
+
+        it('infers class definitions inside layers', async () => {
+            const filepath = path.join(__dirname, 'styles', 'atrules.scss');
+            const result = await filePathToClassnameDict(
+                filepath,
+                getTransformer(false),
+            );
+
+            expect(result).toMatchSnapshot();
+        });
     });
 
     describe('SASS', () => {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -236,6 +236,16 @@ function getParentRule(node: Node): undefined | Node {
     return getParentRule(parent);
 }
 
+const AT_RULES_WITH_SELECTORS = new Set([
+    'container',
+    'document',
+    'layer',
+    'media',
+    'scope',
+    'starting-style',
+    'supports',
+]);
+
 /**
  * input `'./path/to/styles.css'`
  *
@@ -307,7 +317,10 @@ export async function filePathToClassnameDict(
             continue;
         }
         if (node.type === 'atrule') {
-            if (node.name.toLowerCase() === 'media' && node.nodes) {
+            if (
+                AT_RULES_WITH_SELECTORS.has(node.name.toLowerCase()) &&
+                node.nodes
+            ) {
                 stack.unshift(...node.nodes);
             }
             commentStack = [];


### PR DESCRIPTION
Currently we explicitly filter out all atrules (except media) that can host selectors with classname. Let's keep an allowlist of capable at rules and handle them when parsing style files.

closes #36 